### PR TITLE
Add scss to webpack config

### DIFF
--- a/client/app/components/pages/ListingsPage/ListingsPage.jsx
+++ b/client/app/components/pages/ListingsPage/ListingsPage.jsx
@@ -1,8 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import { observer } from 'mobx-react';
 
+import './ListingsPage.scss';
 import ListingsState from './ListingsState.js';
-
 
 @observer export default class ListingsPage extends Component {
   static propTypes = {
@@ -14,9 +14,9 @@ import ListingsState from './ListingsState.js';
 
   render() {
     return (
-      <div>
+      <div className="ListingsPage">
         <h2>This is the listings index page </h2>
-        <p>
+        <p className="ListingsPage__description">
           This is rendered from mobx state: {this.props.listingsState.get('hello')}
         </p>
       </div>

--- a/client/app/components/pages/ListingsPage/ListingsPage.scss
+++ b/client/app/components/pages/ListingsPage/ListingsPage.scss
@@ -1,0 +1,5 @@
+.ListingsPage {
+  &__description {
+    color: blue;
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-runtime": "^6.20.0",
+    "css-loader": "^0.26.1",
     "es5-shim": "^4.5.9",
     "eslint": "^3.14.0",
     "eslint-config-airbnb": "^14.0.0",
@@ -39,11 +40,14 @@
     "imports-loader": "^0.7.0",
     "mobx": "^3.0.2",
     "mobx-react": "^4.1.0",
+    "node-sass": "^4.3.0",
     "react": "^15.4.1",
     "react-bootstrap": "^0.30.7",
     "react-dom": "^15.4.1",
     "react-on-rails": "6.4.2",
     "react-router": "^3.0.2",
+    "sass-loader": "^4.1.1",
+    "style-loader": "^0.13.1",
     "webpack": "^1.14.0"
   },
   "devDependencies": {}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -49,6 +49,10 @@ const config = {
         loader: 'babel-loader',
         exclude: /node_modules/,
       },
+      {
+        test: /\.scss$/,
+        loaders: ['style-loader', 'css-loader', 'sass-loader']
+      }
     ],
   },
   eslint: {


### PR DESCRIPTION
Allows us to use scss with webpack instead of relying on the rails asset pipeline.